### PR TITLE
Add slide mode toggle for theory sets

### DIFF
--- a/app2.js
+++ b/app2.js
@@ -23,6 +23,14 @@ document.addEventListener('DOMContentLoaded', () => {
     // const footerTimeScoreEl = document.getElementById('footerTimeScore')?.querySelector('span'); // This element might not exist
     const footerProgressBarEl = document.getElementById('footerProgressBar');
     const roundInfoDisplayEl = document.getElementById('roundInfoDisplay'); // New element for round info
+
+    // Parse query parameters for selected question IDs
+    function getSelectedIds() {
+        const params = new URLSearchParams(window.location.search);
+        const idsParam = params.get('ids');
+        if (!idsParam) return [];
+        return idsParam.split(',').map(id => id.trim()).filter(Boolean);
+    }
  
  
     // Popup
@@ -48,7 +56,9 @@ document.addEventListener('DOMContentLoaded', () => {
     let audioContext;
     let currentAudio = null;
     let sequenceInProgress = false;
-    let answerShown = false;    const OPTION_KEYS = ['a', 'b', 'c', 'd', 'e', 'g']; // Possible option keys
+    let answerShown = false;
+    const OPTION_KEYS = ['a', 'b', 'c', 'd', 'e', 'g']; // Possible option keys
+    let selectedIds = [];
       // Background styles for cleanup purposes only
     const backgroundStyles = [
         'bg-default', 'bg-abstract', 'bg-wave', 'bg-svg-pattern-1', 'bg-svg-pattern-2', 'bg-svg-pattern-3'
@@ -768,12 +778,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
 
+            selectedIds = getSelectedIds();
+            if (selectedIds.length > 0) {
+                allQuestions = allQuestions.filter(q => selectedIds.includes(q.id));
+            }
+
             if (allQuestions.length > 0) {
                 // Update round info display
                 updateRoundInfoDisplay();
                 renderSlide(allQuestions[currentQuestionIndex]);
             } else {
-                progressTextEl.textContent = "Không tìm thấy câu hỏi nào trong file vong2.json.";
+                progressTextEl.textContent = "Không tìm thấy câu hỏi phù hợp.";
             }
         } catch (error) {
             console.error("Could not load questions:", error);

--- a/lythuyet.html
+++ b/lythuyet.html
@@ -148,6 +148,17 @@
                 <p class="text-xl text-blue-100 font-semibold">
                     Chọn chủ đề để tham gia các bộ đề lý thuyết
                 </p>
+                <!-- Display mode toggle -->
+                <div class="mt-4 flex justify-center">
+                    <div class="bg-white/90 backdrop-blur-sm rounded-full p-1 flex items-center space-x-1 shadow-lg border border-blue-200 text-sm">
+                        <button id="detailModeBtn" class="px-3 py-1 rounded-full font-semibold transition-all duration-300 bg-blue-600 text-white shadow-md">
+                            Chi tiết
+                        </button>
+                        <button id="slideModeBtn" class="px-3 py-1 rounded-full font-semibold transition-all duration-300 text-blue-700 hover:bg-blue-50">
+                            Trình chiếu
+                        </button>
+                    </div>
+                </div>
             </div>
 
             <!-- Theory Cards Grid -->
@@ -351,14 +362,42 @@
             }
         };
 
+        // Display mode control - true for detail page, false for slide
+        let detailMode = localStorage.getItem('lythuyet-display-mode') === 'slide' ? false : true;
+
+        const detailModeBtn = document.getElementById('detailModeBtn');
+        const slideModeBtn = document.getElementById('slideModeBtn');
+
+        function initializeModeToggle() {
+            detailModeBtn.addEventListener('click', () => setDisplayMode(true));
+            slideModeBtn.addEventListener('click', () => setDisplayMode(false));
+        }
+
+        function setDisplayMode(isDetail) {
+            detailMode = isDetail;
+            localStorage.setItem('lythuyet-display-mode', isDetail ? 'detail' : 'slide');
+
+            if (isDetail) {
+                detailModeBtn.className = 'px-3 py-1 rounded-full font-semibold transition-all duration-300 bg-blue-600 text-white shadow-md';
+                slideModeBtn.className = 'px-3 py-1 rounded-full font-semibold transition-all duration-300 text-blue-700 hover:bg-blue-50';
+            } else {
+                detailModeBtn.className = 'px-3 py-1 rounded-full font-semibold transition-all duration-300 text-blue-700 hover:bg-blue-50';
+                slideModeBtn.className = 'px-3 py-1 rounded-full font-semibold transition-all duration-300 bg-blue-600 text-white shadow-md';
+            }
+        }
+
         // Function to start a quiz
         function startQuiz(category, setNumber) {
-            // Store the selected category and set number in localStorage
             localStorage.setItem('selectedCategory', category);
             localStorage.setItem('selectedSet', setNumber);
-            
-            // Navigate to the quiz page
-            window.location.href = 'showquiz.html';
+
+            if (detailMode) {
+                window.location.href = 'showquiz.html';
+            } else {
+                const ids = (quizSets[category][setNumber] || []).join(',');
+                const params = new URLSearchParams({ ids });
+                window.location.href = `vong2.html?${params.toString()}`;
+            }
         }
 
         // Generate quiz sets automatically based on question availability
@@ -408,8 +447,13 @@
             } catch (error) {
                 console.error('Error generating quiz sets:', error);
             }
-        }        // Initialize quiz sets when page loads
-        document.addEventListener('DOMContentLoaded', generateQuizSets);
+        }
+        // Initialize when page loads
+        document.addEventListener('DOMContentLoaded', () => {
+            generateQuizSets();
+            initializeModeToggle();
+            setDisplayMode(detailMode);
+        });
 
         // Add keyboard navigation
         document.addEventListener('keydown', function(e) {


### PR DESCRIPTION
## Summary
- add a small mode toggle to `lythuyet.html`
- support switching between detail and slide view
- pass selected question IDs to `vong2.html`
- update `app2.js` to accept `ids` query parameter and filter questions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68435489d108832aa9b274992b23ac6c