### PR TITLE
Update vong2 image layout

### DIFF
--- a/app2.js
+++ b/app2.js
@@ -14,6 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const optionsContainerEl = document.getElementById('optionsContainer'); 
     const imageAreaEl = document.getElementById('imageArea'); 
     const slideImageEl = document.getElementById('slideImage');
+    const imageModalEl = document.getElementById('imageModal');
+    const modalImageEl = document.getElementById('modalImage');
     // Footer elements
     const footerEl = document.querySelector('.footer'); 
     const progressTextEl = document.getElementById('progressText'); // ID remains the same, but element is in new footer
@@ -328,6 +330,10 @@ document.addEventListener('DOMContentLoaded', () => {
             imageAreaEl.style.order = ''; // Reset order
             imageAreaEl.classList.add('hidden'); // Default to hidden
         }
+        if (imageWrapperEl) {
+            imageWrapperEl.classList.remove('relative', 'w-full', 'question-image');
+            imageWrapperEl.classList.add('absolute', 'inset-y-0', 'right-0', 'w-[calc(100%+3rem)]', 'custom-image-shape');
+        }
 
 
         slideImageEl.onload = () => {
@@ -360,12 +366,16 @@ document.addEventListener('DOMContentLoaded', () => {
             // imageAreaEl.classList.remove('hidden'); // Handled by onload
 
             if (questionData.question_image === 'Yes') {
-                mainContentFlexContainer.classList.add('flex-col');
-                questionOptionsSection.classList.add('w-full');
+                mainContentFlexContainer.classList.add('flex-row');
+                questionOptionsSection.classList.add('w-2/5', 'pr-6');
                 questionOptionsSection.style.order = 1;
-                imageAreaEl.classList.add('w-full', 'h-2/3', 'py-4'); // Adjust image height as needed
+                imageAreaEl.classList.add('w-3/5', 'pl-6');
                 imageAreaEl.style.order = 2;
                 slideImageEl.classList.replace('object-cover', 'object-contain');
+                if (imageWrapperEl) {
+                    imageWrapperEl.classList.remove('absolute', 'inset-y-0', 'right-0', 'w-[calc(100%+3rem)]', 'custom-image-shape');
+                    imageWrapperEl.classList.add('relative', 'w-full', 'question-image');
+                }
             } else if (questionData.position_image === 'Left') {
                 mainContentFlexContainer.classList.add('flex-row');
                 questionOptionsSection.classList.add('w-3/5', 'pl-6');
@@ -555,7 +565,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         // 3. Show & Speak Options (if Trac nghiem)
-        if (currentQuestionData.type_question === "Trắc nghiệm" && currentQuestionData.phuong_an) {
+        if ((currentQuestionData.type_question === "Trắc nghiệm" || currentQuestionData.type_question === "Trắc nghiệm Hình ảnh") && currentQuestionData.phuong_an) {
             const optionElements = optionsContainerEl.querySelectorAll('.option-card');
             console.log(`startQuestionSequence: Found ${optionElements.length} option elements to animate.`);
             
@@ -641,7 +651,7 @@ document.addEventListener('DOMContentLoaded', () => {
         showAnswerBtn.classList.add('opacity-50', 'cursor-not-allowed');
         
         let answerDisplayString = "";
-        if (currentQuestionData.type_question === "Trắc nghiệm") {
+        if (currentQuestionData.type_question === "Trắc nghiệm" || currentQuestionData.type_question === "Trắc nghiệm Hình ảnh") {
             if (currentQuestionData.dap_an_dung) {
                 const correctKeys = Array.isArray(currentQuestionData.dap_an_dung) 
                                     ? currentQuestionData.dap_an_dung 
@@ -811,6 +821,17 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Event Listeners ---
     startSequenceBtn.addEventListener('click', startQuestionSequence);
     showAnswerBtn.addEventListener('click', displayAnswer);
+    if (slideImageEl && imageModalEl && modalImageEl) {
+        slideImageEl.addEventListener('click', () => {
+            if (!slideImageEl.src) return;
+            modalImageEl.src = slideImageEl.src;
+            imageModalEl.classList.remove('hidden');
+        });
+        imageModalEl.addEventListener('click', () => {
+            imageModalEl.classList.add('hidden');
+            modalImageEl.src = '';
+        });
+    }
 
     document.addEventListener('keydown', (e) => {
         if (e.key === 'ArrowRight') {

--- a/lythuyet.html
+++ b/lythuyet.html
@@ -157,6 +157,9 @@
                         <button id="slideModeBtn" class="px-3 py-1 rounded-full font-semibold transition-all duration-300 text-blue-700 hover:bg-blue-50">
                             Mode 2
                         </button>
+                        <a href="page3.html" class="ml-3 text-blue-700 hover:text-blue-900">
+                            <i class="fas fa-home"></i>
+                        </a>
                     </div>
                 </div>
             </div>
@@ -319,47 +322,22 @@
                         </button>
                     </div>
                 </div>
-            </div>            <!-- Back to home button -->
-            <div class="text-center mt-12">
-                <a href="page3.html" class="inline-block bg-white text-blue-600 px-8 py-4 rounded-full font-bold text-lg hover:bg-gray-100 transition-colors duration-300 shadow-lg">
-                    <i class="fas fa-home"></i>
-                </a>
             </div>
             </div>
         </div>
-    </div>
 
     <script>
-        // Quiz set configurations for each category
-        const quizSets = {
-            ly_thuyet_boc_xep_bao_quan_van_chuyen: {
-                1: [], // Will be populated dynamically
-                2: [],
-                3: [],
-                4: [],
-                5: []
-            },
-            ly_thuyet_bao_ve: {
-                1: [],
-                2: [],
-                3: [],
-                4: [],
-                5: [],
-                6: [],
-                7: [],
-                8: []
-            },
-            ly_thuyet_khai_thac_mo: {
-                1: [],
-                2: [],
-                3: [],
-                4: [],
-                5: [],
-                6: [],
-                7: [],
-                8: []
+        let quizSets = {};
+
+        async function loadQuizSets() {
+            try {
+                const res = await fetch('question_sets.json');
+                const data = await res.json();
+                quizSets = data.vong2 || {};
+            } catch (err) {
+                console.error('Error loading question sets:', err);
             }
-        };
+        }
         // Display mode control - true for detail page, false for slide
         let detailMode = localStorage.getItem('lythuyet-display-mode') === 'slide' ? false : true;
 
@@ -400,57 +378,9 @@
             }
         }
 
-        // Generate quiz sets automatically based on question availability
-        async function generateQuizSets() {
-            try {
-                const response = await fetch('vong2.json');
-                const data = await response.json();
-                
-                // Process each category
-                Object.keys(quizSets).forEach(category => {
-                    if (data.vong_2[category] && data.vong_2[category].trac_nghiem) {
-                        const questions = data.vong_2[category].trac_nghiem;
-                        
-                        // Separate theory and image questions
-                        const theoryQuestions = questions.filter(q => q.question_image === "No");
-                        const imageQuestions = questions.filter(q => q.question_image === "Yes");
-                        
-                        // Generate quiz sets (1 theory + 2 image questions per set)
-                        const maxSets = Math.min(
-                            theoryQuestions.length,
-                            Math.floor(imageQuestions.length / 2),
-                            Object.keys(quizSets[category]).length
-                        );
-                        
-                        for (let i = 0; i < maxSets; i++) {
-                            const setQuestions = [];
-                            
-                            // Add 1 theory question
-                            if (theoryQuestions[i]) {
-                                setQuestions.push(theoryQuestions[i].id);
-                            }
-                            
-                            // Add 2 image questions
-                            if (imageQuestions[i * 2]) {
-                                setQuestions.push(imageQuestions[i * 2].id);
-                            }
-                            if (imageQuestions[i * 2 + 1]) {
-                                setQuestions.push(imageQuestions[i * 2 + 1].id);
-                            }
-                            
-                            quizSets[category][i + 1] = setQuestions;
-                        }
-                    }
-                });
-                
-                console.log('Generated quiz sets:', quizSets);
-            } catch (error) {
-                console.error('Error generating quiz sets:', error);
-            }
-        }
         // Initialize when page loads
-        document.addEventListener('DOMContentLoaded', () => {
-            generateQuizSets();
+        document.addEventListener('DOMContentLoaded', async () => {
+            await loadQuizSets();
             initializeModeToggle();
             setDisplayMode(detailMode);
         });

--- a/page3.html
+++ b/page3.html
@@ -515,6 +515,9 @@
             
             card.innerHTML = `
                 <div class="round-indicator" data-round="${roundNumber}">${roundNumber}</div>
+                <button class="view-questions-btn absolute top-1 left-1 bg-gradient-to-r ${getGradientColor(roundNumber)} text-white px-3 py-1 rounded-full text-xs font-semibold hover:shadow-md transform hover:scale-105">
+                    <i class="fas fa-eye"></i>
+                </button>
                 <div class="mb-4">
                     <div class="text-4xl ${color} mb-3">${icon}</div>
                     <h3 class="text-xl font-bold text-gray-800 mb-2">Vòng ${roundNumber}</h3>
@@ -559,11 +562,6 @@
                     `).join('')}
                 </div>
                 
-                <div class="mt-4 pt-4 border-t border-gray-200">
-                    <button class="view-questions-btn w-full bg-gradient-to-r ${getGradientColor(roundNumber)} text-white py-3 px-4 rounded-lg font-semibold transition-all hover:shadow-lg transform hover:scale-105 text-sm">
-                        <i class="fas fa-eye mr-2"></i>Xem chi tiết
-                    </button>
-                </div>
             `;
 
             // Add click event for round indicator (number) to navigate to respective HTML file

--- a/question_sets.json
+++ b/question_sets.json
@@ -1,0 +1,42 @@
+{
+  "vong1": {
+    "1": ["CSPL_TN_1","CSPL_TN_2","CSPL_TN_3","CSPL_TN_4","CSPL_TN_5","YT_SC_TN_1","YT_SC_TN_2","YT_SC_TN_3","PCCC_TN_1","PCCC_TN_2","PCCC_TN_3","PCCC_TN_4","PCCC_TN_5","PCCC_TN_6","PCCC_TN_7"]
+  },
+  "vong2": {
+    "ly_thuyet_boc_xep_bao_quan_van_chuyen": {
+      "1": ["V2_BXV_LT_1","V2_BXV_HA_8","V2_BXV_HA_9"],
+      "2": ["V2_BXV_LT_8","V2_BXV_HA_11","V2_BXV_HA_10"],
+      "3": ["V2_BXV_LT_2","V2_BXV_HA_3","V2_BXV_HA_4"],
+      "4": ["V2_BXV_LT_3","V2_BXV_HA_5","V2_BXV_HA_6"],
+      "5": ["V2_BXV_LT_4","V2_BXV_HA_7","V2_BXV_HA_12"]
+    },
+    "ly_thuyet_bao_ve": {
+      "1": ["V2_BV_LT_1","V2_BV_HA_1","V2_BV_HA_2"],
+      "2": ["V2_BV_LT_2","V2_BV_HA_3","V2_BV_HA_4"],
+      "3": ["V2_BV_LT_3","V2_BV_HA_5","V2_BV_HA_6"],
+      "4": ["V2_BV_LT_4","V2_BV_HA_7","V2_BV_HA_8"],
+      "5": ["V2_BV_LT_5","V2_BV_HA_9","V2_BV_HA_1"],
+      "6": ["V2_BV_LT_6","V2_BV_HA_2","V2_BV_HA_3"],
+      "7": ["V2_BV_LT_7","V2_BV_HA_4","V2_BV_HA_5"],
+      "8": ["V2_BV_LT_8","V2_BV_HA_6","V2_BV_HA_7"]
+    },
+    "ly_thuyet_khai_thac_mo": {
+      "1": ["V2_KTM_LT_11","V2_KTM_LT_14","V2_KTM_HA_4"],
+      "2": ["V2_KTM_LT_2","V2_KTM_HA_3","V2_KTM_HA_4"],
+      "3": ["V2_KTM_LT_3","V2_KTM_HA_5","V2_KTM_HA_6"],
+      "4": ["V2_KTM_LT_4","V2_KTM_HA_7","V2_KTM_HA_8"],
+      "5": ["V2_KTM_LT_5","V2_KTM_HA_9","V2_KTM_HA_10"],
+      "6": ["V2_KTM_LT_6","V2_KTM_HA_11","V2_KTM_HA_12"],
+      "7": ["V2_KTM_LT_7","V2_KTM_HA_13","V2_KTM_HA_14"],
+      "8": ["V2_KTM_LT_8","V2_KTM_HA_15","V2_KTM_HA_1"]
+    }
+  },
+  "vong3": {
+    "1": ["V3_YT_SC_TH_1","V3_PCCC_TL_1"],
+    "2": ["V3_YT_SC_TH_2","V3_PCCC_TL_2"],
+    "3": ["V3_YT_SC_TH_3","V3_PCCC_TL_3"],
+    "4": ["V3_YT_SC_TH_4","V3_PCCC_TL_4"],
+    "5": ["V3_YT_SC_TH_5","V3_PCCC_TL_5"],
+    "6": ["V3_YT_SC_TH_6","V3_PCCC_TL_6"]
+  }
+}

--- a/showquiz.html
+++ b/showquiz.html
@@ -597,36 +597,17 @@
         // Display mode: 1 = All content shown immediately, 2 = Sequential display with audio sync
         let displayMode = parseInt(localStorage.getItem('quizDisplayMode')) || 1;
 
-        // Quiz set definitions (based on your requirements)
-        const quizSets = {
-            ly_thuyet_boc_xep_bao_quan_van_chuyen: {
-                1: ['V2_BXV_LT_1', 'V2_BXV_HA_8', 'V2_BXV_HA_9'],
-                2: ['V2_BXV_LT_8', 'V2_BXV_HA_11', 'V2_BXV_HA_10'],
-                3: ['V2_BXV_LT_2', 'V2_BXV_HA_3', 'V2_BXV_HA_4'],
-                4: ['V2_BXV_LT_3', 'V2_BXV_HA_5', 'V2_BXV_HA_6'],
-                5: ['V2_BXV_LT_4', 'V2_BXV_HA_7', 'V2_BXV_HA_12']
-            },
-            ly_thuyet_bao_ve: {
-                1: ['V2_BV_LT_1', 'V2_BV_HA_1', 'V2_BV_HA_2'],
-                2: ['V2_BV_LT_2', 'V2_BV_HA_3', 'V2_BV_HA_4'],
-                3: ['V2_BV_LT_3', 'V2_BV_HA_5', 'V2_BV_HA_6'],
-                4: ['V2_BV_LT_4', 'V2_BV_HA_7', 'V2_BV_HA_8'],
-                5: ['V2_BV_LT_5', 'V2_BV_HA_9', 'V2_BV_HA_1'],
-                6: ['V2_BV_LT_6', 'V2_BV_HA_2', 'V2_BV_HA_3'],
-                7: ['V2_BV_LT_7', 'V2_BV_HA_4', 'V2_BV_HA_5'],
-                8: ['V2_BV_LT_8', 'V2_BV_HA_6', 'V2_BV_HA_7']
-            },
-            ly_thuyet_khai_thac_mo: {
-                1: ['V2_KTM_LT_11', 'V2_KTM_LT_14', 'V2_KTM_HA_4'],
-                2: ['V2_KTM_LT_2', 'V2_KTM_HA_3', 'V2_KTM_HA_4'],
-                3: ['V2_KTM_LT_3', 'V2_KTM_HA_5', 'V2_KTM_HA_6'],
-                4: ['V2_KTM_LT_4', 'V2_KTM_HA_7', 'V2_KTM_HA_8'],
-                5: ['V2_KTM_LT_5', 'V2_KTM_HA_9', 'V2_KTM_HA_10'],
-                6: ['V2_KTM_LT_6', 'V2_KTM_HA_11', 'V2_KTM_HA_12'],
-                7: ['V2_KTM_LT_7', 'V2_KTM_HA_13', 'V2_KTM_HA_14'],
-                8: ['V2_KTM_LT_8', 'V2_KTM_HA_15', 'V2_KTM_HA_1']
+        let quizSets = {};
+
+        async function loadQuizSets() {
+            try {
+                const res = await fetch('question_sets.json');
+                const data = await res.json();
+                quizSets = data.vong2 || {};
+            } catch (err) {
+                console.error('Error loading question sets:', err);
             }
-        };
+        }
 
         // Initialize quiz
         async function initializeQuiz() {
@@ -1312,8 +1293,13 @@
         }
 
         // Initialize when page loads
-        document.addEventListener('DOMContentLoaded', initializeQuiz);        // Enhanced keyboard navigation with audio controls and display mode toggle        document.addEventListener('keydown', function(e) {        // Enhanced keyboard navigation with audio controls and display mode toggle
-        document.addEventListener('keydown', function(e) {
+        document.addEventListener("DOMContentLoaded", async () => {
+            await loadQuizSets();
+            initializeQuiz();
+        });
+
+        // Enhanced keyboard navigation with audio controls and display mode toggle
+        document.addEventListener("keydown", function(e) {
             if (e.key === 'ArrowLeft') {
                 e.preventDefault();
                 previousQuestion(); // stopAllAudio() đã được gọi trong hàm này

--- a/style.css
+++ b/style.css
@@ -611,6 +611,12 @@ body, html {
     border-bottom-right-radius: 0px;  /* No radius for bottom-right */
 }
 
+/* Image used as main question content */
+.question-image {
+    border: 2px solid #d1d5db; /* gray-300 */
+    border-radius: 6px;
+}
+
 /* --- New Background Styles --- */
 
 /* --- New Background Styles --- */
@@ -682,4 +688,15 @@ body, html {
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
+}
+
+/* Fullscreen image modal */
+.image-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10050;
 }

--- a/vong2.html
+++ b/vong2.html
@@ -77,7 +77,7 @@
             <!-- Right Column: Image -->
             <div id="imageArea" class="w-2/5 flex items-stretch justify-start relative">
             <div id="imageWrapper" class="absolute inset-y-0 right-0 w-[calc(100%+3rem)] custom-image-shape overflow-hidden shadow-xl">
-                <img id="slideImage" src="" alt="Hình ảnh minh họa" class="block w-full h-full object-cover">
+                <img id="slideImage" src="" alt="Hình ảnh minh họa" class="block w-full h-full object-cover cursor-pointer">
             </div>
             </div>
         </div>
@@ -125,6 +125,11 @@
                     Các đội vui lòng giơ bảng đáp án
                 </div>
             </div>
+        </div>
+
+        <!-- Image Modal for full-screen view -->
+        <div id="imageModal" class="image-modal hidden">
+            <img id="modalImage" src="" alt="Preview" class="max-w-full max-h-full">
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- enlarge question images in round 2 slides
- allow clicking the main image to view fullscreen
- tweak styles for question images and modal overlay
- add question set file and load sets dynamically
- move home button on theory page and relocate detail buttons

## Testing
- `node --check app2.js`


------
https://chatgpt.com/codex/tasks/task_e_6843fc1e811c832a9e27eb90a00d3508