### PR TITLE
Add control page with basic settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 // npx http-server -o --no-cache
 document.addEventListener('DOMContentLoaded', () => {
+    applyFontSettings();
     // DOM Elements
     const slideContainer = document.getElementById('slideContainer');
     // Header elements
@@ -30,12 +31,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Configuration ---
     const DEBUG_MODE = false; // Set to true to enable debug mode
-    const USE_SPEECH = true; // Set to false to disable all speech synthesis & audio file playback
+    const USE_SPEECH = localStorage.getItem("useSpeech") !== "false";
     const SHOW_IMAGE_PLACEHOLDER_ON_ERROR = true; // If true, shows a placeholder if an image fails to load
     const IMAGE_PLACEHOLDER_SVG = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23cbd5e1'%3E%3Cpath d='M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z'/%3E%3C/svg%3E"; // Simple image icon
     const DELAY_NO_SPEECH_QUESTION = 1000; // ms to wait after showing question if no speech
     const DELAY_NO_SPEECH_OPTION = 500;  // ms to wait after showing an option if no speech
     const DELAY_NO_SPEECH_ANSWER = 1000; // ms to wait after showing answer if no speech
+
+    function applyFontSettings(){
+        const qSize = localStorage.getItem("fontSizeQuestion");
+        const oSize = localStorage.getItem("fontSizeOption");
+        if(qSize) document.documentElement.style.setProperty("--question-font-size", qSize+"px");
+        if(oSize) document.documentElement.style.setProperty("--option-font-size", oSize+"px");
+    }
 
     // State variables
     let allQuestions = [];

--- a/control.html
+++ b/control.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cài đặt Trình chiếu</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <style>
+        * { font-family: 'Inter', sans-serif; }
+    </style>
+</head>
+<body class="min-h-screen flex items-center justify-center bg-gray-100">
+    <div class="bg-white rounded-xl shadow-xl p-8 w-full max-w-lg space-y-6">
+        <h1 class="text-2xl font-bold text-center">Cài đặt Trình chiếu</h1>
+        <div class="space-y-4">
+            <div class="flex items-center justify-between">
+                <label for="displayMode" class="font-semibold">Kiểu hiển thị đáp án</label>
+                <select id="displayMode" class="border rounded px-2 py-1">
+                    <option value="1">Lần lượt hiện kèm âm thanh</option>
+                    <option value="2">Hiện hết rồi đọc từng phương án</option>
+                </select>
+            </div>
+            <div class="flex items-center justify-between">
+                <label for="useSpeech" class="font-semibold">Sử dụng âm thanh</label>
+                <input id="useSpeech" type="checkbox" class="h-5 w-5 text-blue-600">
+            </div>
+            <div class="flex items-center justify-between">
+                <label for="autoStart" class="font-semibold">Tự động bắt đầu</label>
+                <input id="autoStart" type="checkbox" class="h-5 w-5 text-blue-600">
+            </div>
+            <div class="flex items-center justify-between">
+                <label for="questionFont" class="font-semibold">Cỡ chữ câu hỏi</label>
+                <input id="questionFont" type="number" min="16" max="60" class="border rounded px-2 py-1 w-24">
+            </div>
+            <div class="flex items-center justify-between">
+                <label for="optionFont" class="font-semibold">Cỡ chữ đáp án</label>
+                <input id="optionFont" type="number" min="14" max="60" class="border rounded px-2 py-1 w-24">
+            </div>
+        </div>
+        <div class="flex justify-between pt-4">
+            <a href="question-manager.html" class="text-blue-600 hover:underline"><i class="fas fa-list mr-1"></i>Quản lý câu hỏi</a>
+            <button id="backBtn" class="bg-gray-700 text-white px-4 py-2 rounded hover:bg-gray-800"><i class="fas fa-arrow-left mr-1"></i>Quay lại</button>
+        </div>
+    </div>
+
+<script>
+function loadSettings() {
+    document.getElementById('displayMode').value = localStorage.getItem('displayMode') || '1';
+    document.getElementById('useSpeech').checked = localStorage.getItem('useSpeech') !== 'false';
+    document.getElementById('autoStart').checked = localStorage.getItem('autoStart') === 'true';
+    document.getElementById('questionFont').value = localStorage.getItem('fontSizeQuestion') || 24;
+    document.getElementById('optionFont').value = localStorage.getItem('fontSizeOption') || 20;
+}
+function saveSetting(key, value) { localStorage.setItem(key, value); }
+
+window.addEventListener('DOMContentLoaded', () => {
+    loadSettings();
+    document.getElementById('displayMode').addEventListener('change', e => saveSetting('displayMode', e.target.value));
+    document.getElementById('useSpeech').addEventListener('change', e => saveSetting('useSpeech', e.target.checked));
+    document.getElementById('autoStart').addEventListener('change', e => saveSetting('autoStart', e.target.checked));
+    document.getElementById('questionFont').addEventListener('change', e => saveSetting('fontSizeQuestion', e.target.value));
+    document.getElementById('optionFont').addEventListener('change', e => saveSetting('fontSizeOption', e.target.value));
+    document.getElementById('backBtn').addEventListener('click', () => { window.location.href = 'page3.html'; });
+    document.addEventListener('keydown', e => { if (e.key.toLowerCase() === 'q') window.location.href = 'page3.html'; });
+});
+</script>
+</body>
+</html>

--- a/page3.html
+++ b/page3.html
@@ -767,5 +767,6 @@
         // Initialize on page load
         document.addEventListener('DOMContentLoaded', loadRounds);
     </script>
+    <a href="control.html" id="openSettings" class="fixed bottom-4 left-4 text-gray-600 opacity-60 hover:opacity-100 z-50"><i class="fas fa-cog fa-lg"></i></a>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -759,3 +759,9 @@ body, html {
     color: #1f2937 !important; /* Ensure text is dark and readable on light background */
     font-weight: 500 !important;
 }
+/* User customizable styles */
+:root { --question-font-size: 1.5rem; --option-font-size: 1.25rem; }
+.question-text { font-size: var(--question-font-size); }
+.option-text { font-size: var(--option-font-size); }
+.audio-highlight { background: rgba(255,235,59,0.25) !important; border-color: #fbbf24 !important; border-width: 3px !important; transform: scale(1.02) !important; transition: all 0.3s ease !important; box-shadow: 0 0 20px rgba(251,191,36,0.4) !important; }
+


### PR DESCRIPTION
## Summary
- add a gear link to open the new Control page
- allow storing answer font sizes and disable audio via localStorage
- include helper classes for custom font sizes and highlights
- implement basic UI for adjusting settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68450d60d7ac832ab683a28475cf2b31